### PR TITLE
startTime.padStart(5, '0') ensures that times like 9:00 are converted…

### DIFF
--- a/MasniOfficeAgenda/src/app/home/agenda/agenda.component.ts
+++ b/MasniOfficeAgenda/src/app/home/agenda/agenda.component.ts
@@ -75,12 +75,13 @@ export class AgendaComponent implements OnInit {
   }
 
   isTimeInSlot(startTime: string, time: { startTime: string, endTime: string }): boolean {
-    const appointmentStartTime = new Date(`1970-01-01T${startTime}:00`);
-    const slotStartTime = new Date(`1970-01-01T${time.startTime}:00`);
-    const slotEndTime = new Date(`1970-01-01T${time.endTime}:00`);
+    const appointmentStartTime = new Date(`1970-01-01T${startTime.padStart(5, '0')}:00`);
+    const slotStartTime = new Date(`1970-01-01T${time.startTime.padStart(5, '0')}:00`);
+    const slotEndTime = new Date(`1970-01-01T${time.endTime.padStart(5, '0')}:00`);
 
     return appointmentStartTime >= slotStartTime && appointmentStartTime < slotEndTime;
   }
+
 
   previousMonth() {
     this.currentMonth = subMonths(this.currentMonth, 1);


### PR DESCRIPTION
… to 09:00.

Using 1970-01-01T ensures that all times are parsed in the same timezone and date context, avoiding potential issues with date comparison.